### PR TITLE
Menu fixes

### DIFF
--- a/PA9SFML/PA9SFML/Game.hpp
+++ b/PA9SFML/PA9SFML/Game.hpp
@@ -38,8 +38,11 @@ public:
 private:
 	GameState currentState = GameState::MENU;
 	Menu* menu = nullptr;
+	float lastInputTime = 0.0f;
+	const float inputCooldown = 0.2f;
+	bool isPaused = false;
 
-	void processEvents();
+	void processEvents(sf::Time dt);
 	void handleMenuState(sf::Time dt);
 	void handlePlayingState(sf::Time dt);
 	void handlePausedState(sf::Time dt);

--- a/PA9SFML/PA9SFML/Menu.cpp
+++ b/PA9SFML/PA9SFML/Menu.cpp
@@ -38,28 +38,32 @@ Menu::~Menu() {
     delete titleText;
 }
 
-void Menu::handleInput() {
-    
-    
-    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Scan::W) || sf::Keyboard::isKeyPressed(sf::Keyboard::Scan::Up)) {
+void Menu::handleInput(float dt) {
+    lastInputTime += dt;
+
+    if (lastInputTime >= inputCooldown) {
+        if (sf::Keyboard::isKeyPressed(sf::Keyboard::Scan::W) || sf::Keyboard::isKeyPressed(sf::Keyboard::Scan::Up)) {
             menuItems[selectedItemIndex].setSelected(false);
             selectedItemIndex = (selectedItemIndex - 1 + static_cast<int>(menuItems.size())) % static_cast<int>(menuItems.size());
             menuItems[selectedItemIndex].setSelected(true);
-    }
-    else if (sf::Keyboard::isKeyPressed(sf::Keyboard::Scan::S) || sf::Keyboard::isKeyPressed(sf::Keyboard::Scan::Down)) {
+            lastInputTime = 0.0f;
+        }
+        else if (sf::Keyboard::isKeyPressed(sf::Keyboard::Scan::S) || sf::Keyboard::isKeyPressed(sf::Keyboard::Scan::Down)) {
             menuItems[selectedItemIndex].setSelected(false);
             selectedItemIndex = (selectedItemIndex + 1) % static_cast<int>(menuItems.size());
             menuItems[selectedItemIndex].setSelected(true);
-    }
-
-    else if (sf::Keyboard::isKeyPressed(sf::Keyboard::Scan::Enter)) {
+            lastInputTime = 0.0f;
+        }
+        else if (sf::Keyboard::isKeyPressed(sf::Keyboard::Scan::Enter)) {
             itemSelected = true;
+            lastInputTime = 0.0f;
+        }
     }
-    
 }
 
+
 void Menu::update(float dt) {
-    // probably dont need
+    handleInput(dt);
 }
 
 void Menu::draw() {

--- a/PA9SFML/PA9SFML/Menu.hpp
+++ b/PA9SFML/PA9SFML/Menu.hpp
@@ -51,7 +51,7 @@ public:
     Menu(sf::RenderWindow& window);
     ~Menu();
 
-    void handleInput();
+    void handleInput(float dt);
     void update(float dt);
     void draw();
 
@@ -64,6 +64,8 @@ private:
     std::vector<MenuItem> menuItems;
     int selectedItemIndex = 0;
     bool itemSelected = false;
+    float lastInputTime = 0.0f;
+    const float inputCooldown = 0.2f;
 
     sf::Font font;
     sf::Text* titleText;


### PR DESCRIPTION
Fixed an issue where the menu would accept inputs every frame, caused by not having a cooldown on the input register. Fixed an issue where the pause menu would flicker wildly and lag out the game, caused by the game re-rendering the pause menu every frame instead of checking if the game is currently paused before rendering.